### PR TITLE
Improve connection quality and latency resilience

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,10 @@ func SaveListenToken(token string) {
 func saveConfig() {
 	viper.SetConfigFile(configFilePath())
 	viper.SetConfigType("yaml")
+
+	viper.Set("username", "")
+	viper.Set("password", "")
+
 	viper.WriteConfig()
 
 }

--- a/context/context.go
+++ b/context/context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"io"
 	"time"
 
 	"github.com/acaloiaro/di-tui/components"
@@ -26,7 +27,8 @@ func CreateAppContext(view *views.ViewContext) *AppContext {
 // View - The view context
 // Status - Gets and sets current application status messages
 type AppContext struct {
-	AudioStream        *pulse.PlaybackStream
+	AudioStream        io.ReadCloser
+	Player             *pulse.PlaybackStream
 	CurrentChannel     *components.ChannelItem
 	DifmToken          string
 	IsPlaying          bool

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 
 	username := viper.GetString("username")
 	password := viper.GetString("password")
+
 	var token string
 	if len(username) > 0 && len(password) > 0 {
 		difm.Authenticate(ctx, username, password)


### PR DESCRIPTION
When users are suffering from poor connection quality/high latency, increase the player buffer until skips stop (they may not, obviously)