### PR TITLE
Fix leaky channel stream bug 

### DIFF
--- a/player/player.go
+++ b/player/player.go
@@ -45,6 +45,7 @@ func Play(ctx *context.AppContext, stream io.ReadWriter, playbackLatency int) (e
 func Stop(ctx *context.AppContext) {
 	ctx.IsPlaying = false
 	if ctx.Player != nil {
+		ctx.AudioStream.Close()
 		ctx.Player.Close()
 	}
 }


### PR DESCRIPTION
Currently when the channel changes, the old HTTP stream is unintentionally left open, wasting and eventually saturating all bandwidth if the user switches channels enough times.

- Fix leaky channel stream when the channel changes
