### PR TITLE
Add version number back to release files

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ archives:
   - id: di-tui
     name_template: >-
       {{ .ProjectName }}_
+      {{- .Verson  }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
The previous commit accidentally removed the version number from release
files. This commit re-introduces release version numbers to release
files.
