### PR TITLE
Simpler album art fetching

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -27,6 +27,7 @@ type CurrentlyPlaying struct {
 
 // Track is metadata about a currently playing di.fm track
 type Track struct {
+	ID        int       `json:"id"`
 	Artist    string    `json:"display_artist"`
 	Title     string    `json:"display_title"`
 	Duration  float64   `json:"duration"`
@@ -37,4 +38,10 @@ type Track struct {
 type StatusMessage struct {
 	Message  string
 	Duration time.Duration
+}
+
+// TrackDetails is metadata about a currently playing di.fm track
+type TrackDetails struct {
+	ID          int    `json:"id"`
+	AlbumArtURL string `json:"asset_url"`
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gdamore/tcell/v2 v2.6.0
 	github.com/hajimehoshi/go-mp3 v0.2.1
 	github.com/jfreymuth/pulse v0.1.0
-	github.com/michiwend/gomusicbrainz v0.0.0-20181012083520-6c07e13dd396
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/rivo/tview v0.0.0-20230621164836-6cc0565babaf
 	github.com/spf13/pflag v1.0.5
@@ -24,7 +23,6 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
-	github.com/michiwend/golang-pretty v0.0.0-20141116172505-8ac61812ea3f // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,10 +76,6 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/michiwend/golang-pretty v0.0.0-20141116172505-8ac61812ea3f h1:oF0u/1VBm5gYitYvcIh443XZuYYkR50CP0Vsj3gAa1o=
-github.com/michiwend/golang-pretty v0.0.0-20141116172505-8ac61812ea3f/go.mod h1:k0nOQg5bmAmEwWAuodvib9B74Oyny6aRMpkBcVWEtKs=
-github.com/michiwend/gomusicbrainz v0.0.0-20181012083520-6c07e13dd396 h1:REpvt1iVqbiiBk2TihujngsSpHHMHiB/JBkQH/qkq8s=
-github.com/michiwend/gomusicbrainz v0.0.0-20181012083520-6c07e13dd396/go.mod h1:HKpGCk/zijJ9GXdTWgtpnd5BbKDXtN0OQ3E4/zpxOwM=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=


### PR DESCRIPTION
Instead of using Music Brainz api, now uses plain AudioAddict.com details api which gives us the specific album cover art for the given Track ID.

We still need to do an extra request in order to get the album art cover image url. Then we do the actual image downloading.