### PR TITLE
fix: flash of mis-colored background color on first status change

### DIFF
--- a/views/views.go
+++ b/views/views.go
@@ -234,6 +234,7 @@ func createStatusView() *StatusView {
 	sv.SetTitleColor(primaryTextColor)
 	sv.SetBorder(true)
 	sv.SetBorderColor(primaryColor)
+	sv.SetBackgroundColor(backgroundColor)
 
 	return sv
 }


### PR DESCRIPTION
When di-tui shows the first status message (e.g. choosing a channel), the background color of the status message view doesn't match the theme/user terminal defaults.