### PR TITLE
docs: clarify that favorites must be edited on the web player

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ DI.fm is the default network, but other audio addict networks can be chosen with
 | jazzradio | Jazz Radio [https://jazzradio.com](https://jazzradio.com)|
 | zenradio |  Zen Radio [https://zenradio.com](https://zenradio.com)|
 
+### Favorites
+
+Favorites must be edited on the web player (e.g. at [DI.fm](https://di.fm)) and cannot be
+edited via this app. It used to be possible to edit favorites from this app, but DI.fm
+introduced limitations on their API.
+
 ## Dependencies
 
 ### PulseAudio


### PR DESCRIPTION
This confused me why I couldn't edit my favorites from the TUI app, as I hadn't used the web player in a while and didn't realise I had set my favorites there.

I tried to add a hint about this on the actual TUI, but couldn't figure out a way to make that look pretty.