### PR TITLE
Network / Favorite name cleanup 

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -10,10 +10,11 @@ import (
 )
 
 // CreateAppContext creates the application context
-func CreateAppContext(view *views.ViewContext) *AppContext {
+func CreateAppContext(vc *views.ViewContext) *AppContext {
 	ctx := &AppContext{
-		View:          view,
+		View:          vc,
 		StatusChannel: make(chan components.StatusMessage, 10),
+		Network:       vc.Network,
 	}
 
 	return ctx

--- a/difm/difm.go
+++ b/difm/difm.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -210,6 +211,9 @@ func ListFavorites(ctx *context.AppContext) (favorites []components.FavoriteItem
 			PlaylistURL: cfg.Section(sec).Key(fmt.Sprintf("File%d", k)).String(),
 		})
 	}
+	slices.SortFunc(favorites, func(a components.FavoriteItem, b components.FavoriteItem) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
 	return
 }

--- a/main.go
+++ b/main.go
@@ -62,7 +62,6 @@ func main() {
 
 	ctx = context.CreateAppContext(views.CreateViewContext(network))
 	ctx.DifmToken = token
-	ctx.Network = network
 
 	run()
 }
@@ -214,8 +213,8 @@ func FetchFavoritesAndChannels() {
 	}
 
 	favorites := difm.ListFavorites(ctx)
-	for _, fav := range favorites {
-		ctx.View.FavoriteList.AddItem(fav.Name, "", 0, func() {})
+	for i, favorite := range favorites {
+		ctx.View.FavoriteList.InsertItem(i, favorite.Name, "", 0, func() {})
 	}
 	ctx.ChannelList = channels
 	ctx.FavoriteList = favorites

--- a/views/views.go
+++ b/views/views.go
@@ -55,6 +55,7 @@ type ViewContext struct {
 	ChannelList  *tview.List
 	FavoriteList *tview.List
 	Keybindings  *KeybindingView
+	Network      *components.Network
 	NowPlaying   *NowPlayingView
 	Status       *StatusView
 }
@@ -95,6 +96,7 @@ func CreateViewContext(network *components.Network) *ViewContext {
 		ChannelList:  createChannelList(),
 		FavoriteList: createFavoriteList(),
 		Keybindings:  createKeybindings(),
+		Network:      network,
 		NowPlaying:   createNowPlaying(network),
 		Status:       createStatusView(),
 	}


### PR DESCRIPTION
- Move the network name to "now playing" title bar
- Remove network name from favorites
- Sort favorites alphabetically 

Fixes #44 
Fixes #42 